### PR TITLE
Have Oauth2 verification use an array of issuers. Add 'https://accounts.google.com' as a valid issuer.

### DIFF
--- a/lib/auth/oauth2client.js
+++ b/lib/auth/oauth2client.js
@@ -101,7 +101,7 @@ OAuth2Client.MAX_TOKEN_LIFETIME_SECS_ = 86400;
  * @const
  * @private
  */
-OAuth2Client.ISSUER_ = 'accounts.google.com';
+OAuth2Client.ISSUERS_ = ['accounts.google.com', 'https://accounts.google.com'];
 
 /**
  * Generates URL for consent page landing.
@@ -400,7 +400,7 @@ OAuth2Client.prototype.verifyIdToken = function(idToken, audience, callback) {
     var login;
     try {
       login = this.verifySignedJwtWithCerts(idToken, certs, audience,
-        OAuth2Client.ISSUER_);
+        OAuth2Client.ISSUERS_);
     } catch (err) {
       callback(err);
       return;
@@ -457,12 +457,12 @@ OAuth2Client.prototype.getFederatedSignonCerts = function(callback) {
  * @param {string} jwt The jwt to verify (The ID Token in this case).
  * @param {array} certs The array of certs to test the jwt against.
  * @param {string} requiredAudience The audience to test the jwt against.
- * @param {string} issuer The issuer of the jwt (Optional).
+ * @param {array} issuers The issuers of the jwt (Optional).
  * @param {string} maxExpiry The max expiry the certificate can be (Optional).
  * @return {LoginTicket} Returns a LoginTicket on verification.
  */
 OAuth2Client.prototype.verifySignedJwtWithCerts =
-  function(jwt, certs, requiredAudience, issuer, maxExpiry) {
+  function(jwt, certs, requiredAudience, issuers, maxExpiry) {
 
     if (!maxExpiry) {
       maxExpiry = OAuth2Client.MAX_TOKEN_LIFETIME_SECS_;
@@ -530,8 +530,8 @@ OAuth2Client.prototype.verifySignedJwtWithCerts =
         JSON.stringify(payload));
     }
 
-    if (issuer && issuer !== payload.iss) {
-      throw new Error('Invalid issuer, ' + issuer + ' != ' + payload.iss);
+    if (issuers && issuers.indexOf(payload.iss) < 0) {
+      throw new Error('Invalid issuer, ' + payload.iss + ' not in ' + issuers);
     }
 
     // Check the audience matches if we have one

--- a/test/test.oauth2.js
+++ b/test/test.oauth2.js
@@ -609,7 +609,7 @@ describe('OAuth2 client', function() {
       data,
       {keyid: publicKey},
       'testaudience',
-      'testissuer',
+      ['testissuer'],
       maxExpiry
     );
 
@@ -762,7 +762,7 @@ describe('OAuth2 client', function() {
           data,
           {keyid: publicKey},
           'testaudience',
-          'testissuer'
+          ['testissuer', 'testissuer2']
         );
       },
       /Invalid issuer/
@@ -811,7 +811,7 @@ describe('OAuth2 client', function() {
       data,
       {keyid: publicKey},
       'testaudience',
-      'testissuer'
+      ['testissuer', 'testissuer2']
     );
 
     done();


### PR DESCRIPTION
Hello @jfuchs, 

Please review the following commits I made in branch 'andrew-authIssuer'.

3e4a38aa28f02e335101f9092290f8f699bf7df5 (2015-10-01 13:28:45 -0700)
Have Oauth2 verification use an array of issuers. Add 'https://accounts.google.com' as a valid issuer.

R=@jfuchs

TESTED=unit tests updated
